### PR TITLE
Publish RIsearch1 to PyPI as risearch-tauso

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,67 @@
+name: Build wheels and publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build manylinux x86_64 wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.3
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist
+        run: |
+          python -m pip install --upgrade build
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # Publish only on tag pushes; manual dispatch builds artifacts but doesn't upload.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/risearch-tauso
+    permissions:
+      # Required for PyPI trusted publishing — no API token needed.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 bin/
 *.o
+
+# Python build artifacts
+build/
+dist/
+*.egg-info/
+src/risearch_tauso/bin/
+__pycache__/
+*.py[cod]
+.venv/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+graft RIsearch1
+include LICENSE
+include README.md
+prune RIsearch2
+prune RIsearch2-siRNA-off-targets
+# Strip pre-built binaries and any build artifacts so the sdist is source-only;
+# the wheel build will recompile from RIsearch1/src.
+exclude RIsearch1/RISearch
+prune RIsearch1/bin
+prune src/risearch_tauso/bin
+prune src/risearch_tauso.egg-info
+global-exclude __pycache__
+global-exclude *.py[cod]
+global-exclude *.o

--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
 # RIsearch
-RIsearch: a tool for large-scale RNA–RNA, RNA-DNA, and DNA-DNA interaction prediction
+RIsearch: a tool for large-scale RNA–RNA, RNA-DNA, and DNA-DNA interaction prediction.
+
+## Python package (RIsearch1, tauso fork)
+
+A precompiled RIsearch1 binary from this fork is published to PyPI under the
+name `risearch-tauso`, to make RIsearch a normal Python dependency for tauso
+and any other downstream tool that wants the fork's flavor of RIsearch1:
+
+```bash
+pip install risearch-tauso
+```
+
+```python
+import risearch_tauso, subprocess
+subprocess.run([risearch_tauso.executable_path(), "-q", "query.fa", "-t", "target.fa"])
+```
+
+Or as a CLI shim (forwards all args straight to the bundled binary):
+
+```bash
+risearch-tauso -q query.fa -t target.fa
+python -m risearch_tauso -q query.fa -t target.fa
+```
+
+The PyPI package is **not** the canonical upstream RIsearch — it is the
+tauso-team fork. Use the upstream RIsearch from RTH-tools if you want the
+unmodified tool. The Python wrapper currently ships **RIsearch1** only;
+RIsearch2 still needs to be built from source per the instructions below.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,59 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "risearch-tauso"
+version = "1.2.0"
+description = "Prebuilt RIsearch1 binary (RNA-RNA / RNA-DNA / DNA-DNA interaction search), tauso fork, packaged for Python."
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "GPL-3.0-or-later"}
+authors = [
+    {name = "Anne Wenzel"},
+    {name = "Giulia I Corsi"},
+]
+maintainers = [
+    {name = "Michael Kovaliov"},
+]
+keywords = ["bioinformatics", "rna", "rna-rna", "rna-dna", "interaction", "antisense", "oligonucleotide"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+
+[project.urls]
+Homepage = "https://github.com/RedPenguin100/risearch"
+Source = "https://github.com/RedPenguin100/risearch"
+Upstream = "https://rth.dk/resources/risearch/"
+
+[project.scripts]
+risearch-tauso = "risearch_tauso.__main__:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.package-data]
+"risearch_tauso" = ["bin/RIsearch"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["risearch_tauso*"]
+
+[tool.cibuildwheel]
+build = "cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64"
+build-verbosity = 1
+# manylinux2014 ships gcc + make, which is all we need.
+manylinux-x86_64-image = "manylinux2014"
+# Smoke-test the wheel after build: the binary must be runnable.
+test-command = "python -c \"import risearch_tauso, subprocess; p = risearch_tauso.executable_path(); print(p); subprocess.run([p, '-h'], check=False)\""

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,136 @@
+"""
+Build hook for the `risearch-tauso` Python package.
+
+The C source for RIsearch1 lives in `RIsearch1/src/` and is compiled by its own
+Makefile to `RIsearch1/bin/RIsearch`. This script wraps that build into a normal
+setuptools step: at wheel-build time it runs `make`, then copies the binary into
+the package as `risearch_tauso/bin/RIsearch` so it ships as package data.
+
+All static metadata is in `pyproject.toml`.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+
+from setuptools import Distribution, setup
+from setuptools.command.build_py import build_py
+from setuptools.command.egg_info import egg_info
+
+try:
+    from wheel.bdist_wheel import bdist_wheel
+except ImportError:  # `wheel` may be absent for sdist-only builds
+    bdist_wheel = None
+
+PACKAGE_NAME = "risearch_tauso"
+BINARY_NAME = "RIsearch"
+
+
+class BinaryDistribution(Distribution):
+    """The wheel ships a compiled binary, so it is platform-specific.
+
+    Without this, setuptools tags the wheel `py3-none-any` and pip on a
+    Windows or macOS machine would happily install a Linux ELF binary.
+    """
+
+    def has_ext_modules(self):
+        return True
+
+
+if bdist_wheel is not None:
+
+    class GenericWheel(bdist_wheel):
+        """Tag the wheel `py3-none-<plat>` instead of `cp3X-cp3X-<plat>`.
+
+        The RIsearch binary is invoked as a subprocess and doesn't link against
+        Python's ABI, so the wheel is compatible with every CPython 3 on a given
+        platform. Without this override, setuptools would pin each wheel to the
+        builder's exact Python minor version.
+        """
+
+        def get_tag(self):
+            _python, _abi, plat = super().get_tag()
+            return "py3", "none", plat
+else:
+    GenericWheel = None
+
+logger = logging.getLogger(__name__)
+
+
+def _build_risearch_binary(force_target_dir=None):
+    """Compile RIsearch1 and copy the binary into the package.
+
+    For `pip install .` / wheel builds, `force_target_dir` is the staged
+    `build/lib/risearch` directory. For `pip install -e .`, it is None and the
+    binary lands in `src/risearch/bin/` so the editable install can find it.
+    """
+    root_dir = os.path.dirname(os.path.abspath(__file__))
+    base_dir = os.path.join(root_dir, "RIsearch1")
+    src_dir = os.path.join(base_dir, "src")
+    bin_dir = os.path.join(base_dir, "bin")
+
+    if force_target_dir:
+        dest_dir = os.path.join(force_target_dir, "bin")
+    else:
+        dest_dir = os.path.join(root_dir, "src", PACKAGE_NAME, "bin")
+
+    dest_path = os.path.join(dest_dir, BINARY_NAME)
+
+    if not force_target_dir and os.path.exists(dest_path):
+        print(f"Binary already exists at {dest_path}, skipping rebuild.")
+        return
+
+    print("--- BUILDING RIsearch ---")
+
+    if not os.path.exists(src_dir):
+        raise FileNotFoundError(
+            f"C source not found at {src_dir}. The sdist should include RIsearch1/."
+        )
+
+    os.makedirs(bin_dir, exist_ok=True)
+    try:
+        subprocess.check_call(["make", "-C", src_dir])
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"make failed to compile RIsearch: {e}")
+
+    compiled_bin = os.path.join(bin_dir, BINARY_NAME)
+    if not os.path.exists(compiled_bin):
+        raise FileNotFoundError(
+            f"make ran successfully, but {compiled_bin} was not produced."
+        )
+
+    os.makedirs(dest_dir, exist_ok=True)
+    shutil.copy(compiled_bin, dest_path)
+    os.chmod(dest_path, 0o755)
+    print(f"Installed {dest_path}")
+
+
+class CustomBuild(build_py):
+    """Triggered by `pip install .` and wheel builds."""
+
+    def run(self):
+        target_dir = os.path.join(self.build_lib, PACKAGE_NAME)
+        _build_risearch_binary(target_dir)
+        super().run()
+
+
+class CustomEggInfo(egg_info):
+    """Triggered by both `pip install .` and `pip install -e .`."""
+
+    def run(self):
+        _build_risearch_binary(force_target_dir=None)
+        super().run()
+
+
+cmdclass = {
+    "build_py": CustomBuild,
+    "egg_info": CustomEggInfo,
+}
+if GenericWheel is not None:
+    cmdclass["bdist_wheel"] = GenericWheel
+
+setup(
+    distclass=BinaryDistribution,
+    cmdclass=cmdclass,
+)

--- a/src/risearch_tauso/__init__.py
+++ b/src/risearch_tauso/__init__.py
@@ -1,0 +1,32 @@
+"""RIsearch1 (tauso fork) packaged for Python.
+
+The C binary is bundled as package data. Use `executable_path()` to locate it
+and invoke it via `subprocess`. RIsearch is a standalone command-line tool;
+this package does not wrap its CLI semantics.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+
+__all__ = ["executable_path", "__version__"]
+
+__version__ = "1.2.0"
+
+_BINARY_NAME = "RIsearch"
+
+
+def executable_path() -> str:
+    """Absolute path to the bundled RIsearch binary, as a string.
+
+    Raises FileNotFoundError if the binary is missing — that means the wheel
+    was built incorrectly or an editable install hasn't compiled it yet.
+    """
+    p = files(__name__) / "bin" / _BINARY_NAME
+    if not Path(str(p)).is_file():
+        raise FileNotFoundError(
+            f"Bundled RIsearch binary not found at {p}. "
+            "If installing in editable mode, ensure `make` succeeded during install."
+        )
+    return str(p)

--- a/src/risearch_tauso/__main__.py
+++ b/src/risearch_tauso/__main__.py
@@ -1,0 +1,22 @@
+"""`python -m risearch_tauso` and the `risearch-tauso` console-script entry point.
+
+Both forward all arguments straight to the bundled RIsearch binary.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from . import executable_path
+
+
+def main() -> "int | None":
+    binary = executable_path()
+    # execv replaces this Python process with RIsearch — the user sees its exit
+    # code and signals directly, no Python wrapper overhead.
+    os.execv(binary, [binary, *sys.argv[1:]])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds Python packaging so this fork's RIsearch1 binary can be installed via `pip install risearch-tauso` and used as a normal dependency by tauso (and any other Python tool).

## What's in the package

- **`risearch-tauso`** on PyPI — wheel ships a precompiled RIsearch1 binary (`py3-none-linux_x86_64`); sdist ships only C sources and recompiles via `make` on install.
- **`risearch_tauso`** Python module — `risearch_tauso.executable_path()` returns the absolute path of the bundled binary.
- **`risearch-tauso` console script** — `execv`s the binary directly so the user sees its real exit code, signals, and stdout/stderr.

The PyPI package is **not** the canonical upstream RIsearch — it is the tauso-team fork. The `-tauso` suffix makes that explicit and avoids any future collision with an official `risearch` package.

## Files

| File | Purpose |
|---|---|
| `pyproject.toml` | name, deps, package data, cibuildwheel config |
| `setup.py` | `make`-based build hook; `BinaryDistribution` + `GenericWheel` for correct wheel tagging |
| `MANIFEST.in` | sdist is source-only (prunes RIsearch2, pre-built binaries, build artifacts) |
| `src/risearch_tauso/__init__.py` | `executable_path()` + `__version__` |
| `src/risearch_tauso/__main__.py` | console-script + `python -m risearch_tauso` |
| `.github/workflows/wheels.yml` | cibuildwheel matrix (cp39–cp313 × manylinux2014 x86_64) + sdist; publishes to PyPI on tag push via trusted publishing |

RIsearch2 and RIsearch2-siRNA-off-targets are untouched and not packaged.

## Local verification

Both install paths produce a working binary:

```bash
python -m build
# wheel install in clean venv:
pip install dist/risearch_tauso-1.2.0-py3-none-linux_x86_64.whl
python -c "import risearch_tauso, subprocess; subprocess.run([risearch_tauso.executable_path()])"
# sdist install in clean venv (forces local make):
pip install dist/risearch_tauso-1.2.0.tar.gz
```

Both end up printing the `====== RIsearch1 ver 1.2 ======` banner from the bundled binary.

## One-time steps before first release

After merging, two manual steps are needed before the first PyPI release:

1. **Reserve the PyPI project + configure trusted publishing.** On https://pypi.org, register a Trusted Publisher for project `risearch-tauso` pointing at this repo, workflow file `wheels.yml`, environment `pypi`. (No API token to manage.)
2. **Tag a release**: `git tag v1.2.0 && git push --tags`. The workflow builds wheels + sdist and uploads them.

## Downstream change

A separate PR on TAUSO will drop the `external/risearch` submodule and the `setup.py` build hook, and add `risearch-tauso>=1.2` to `dependencies` in `pyproject.toml`. The lookup in `fast_hybridization.py` changes from `files("tauso") / "out" / "risearch_executable"` to `risearch_tauso.executable_path()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)